### PR TITLE
Adds test center / staging models - update geolocation on save/update

### DIFF
--- a/src/server/db/models/testcenter.js
+++ b/src/server/db/models/testcenter.js
@@ -29,10 +29,33 @@ module.exports = (sequelize, DataTypes) => {
       closed: DataTypes.BOOLEAN,
       date_closed: DataTypes.DATE,
     },
-    {}
+    {
+      hooks: {
+        beforeCreate: (testCenter) => {
+          return updateGeolocation(testCenter)
+        },
+        beforeUpdate: (testCenter) => {
+          return updateGeolocation(testCenter)
+        },
+      },
+    }
   )
   TestCenter.associate = function (models) {
     // associations can be defined here
+  }
+
+  const updateGeolocation = async (testCenter) => {
+    if (testCenter.changed('latitude') || testCenter.changed('longitutde')) {
+      if (testCenter.longitude === null || testCenter.latitude === null) {
+        return
+      }
+
+      testCenter.geolocation = {
+        type: 'Point',
+        coordinates: [testCenter.longitude, testCenter.latitude],
+        crs: { type: 'name', properties: { name: 'EPSG:4326' } },
+      }
+    }
   }
   return TestCenter
 }

--- a/src/server/db/models/testcenterstaging.js
+++ b/src/server/db/models/testcenterstaging.js
@@ -29,10 +29,39 @@ module.exports = (sequelize, DataTypes) => {
       closed: DataTypes.BOOLEAN,
       date_closed: DataTypes.DATE,
     },
-    {}
+    {
+      hooks: {
+        beforeCreate: (testCenterStaging) => {
+          return updateGeolocation(testCenterStaging)
+        },
+        beforeUpdate: (testCenterStaging) => {
+          return updateGeolocation(testCenterStaging)
+        },
+      },
+    }
   )
   TestCenterStaging.associate = function (models) {
     // associations can be defined here
+  }
+
+  const updateGeolocation = async (testCenterStaging) => {
+    if (
+      testCenterStaging.changed('latitude') ||
+      testCenterStaging.changed('longitutde')
+    ) {
+      if (
+        testCenterStaging.longitude === null ||
+        testCenterStaging.latitude === null
+      ) {
+        return
+      }
+
+      testCenterStaging.geolocation = {
+        type: 'Point',
+        coordinates: [testCenterStaging.longitude, testCenterStaging.latitude],
+        crs: { type: 'name', properties: { name: 'EPSG:4326' } },
+      }
+    }
   }
   return TestCenterStaging
 }


### PR DESCRIPTION
This update adds hooks to beforeCreate / beforeUpdate on test_centers / test_center_staging populating geolocation.