### PR TITLE
switch prod api to production (was formerly staging)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_GTC_API_URL=https://staging.api.get-tested-covid19.org
+REACT_APP_GTC_API_URL=https://api.get-tested-covid19.org


### PR DESCRIPTION
we currently don't have a way to set staging and prod REACT_APP strings to different variables, terraform environment variables weren't working for the react-scripts build script