### PR TITLE
Fixes pagination when searching a new zip code

### DIFF
--- a/src/components/results/ResultsPage.js
+++ b/src/components/results/ResultsPage.js
@@ -146,6 +146,7 @@ class ResultsPage extends React.Component {
       if (getQueryStringValue('zip') !== this.zip) {
         this.zip = getQueryStringValue('zip');
         this.filterList(this.zip);
+
         // Scroll to top of page
         window.scrollTo({ top: 0, behavior: 'smooth' });
       }
@@ -169,20 +170,23 @@ class ResultsPage extends React.Component {
               this.zipLatLng = response.data.coords;
               this.resultsZip = response.data.testCenters;
               this.setState({
-                isFetching: false
+                isFetching: false,
+                currentPage: 0
               })
             })
             .catch(err => {
-              console.log(err);
+              //console.log(err);
               this.resultsZip = [];
               this.setState({
-                isFetching: false
+                isFetching: false,
+                currentPage: 0
               })
             });
         } else {
           this.setState({
             isFetching: false,
-            hasError: 'INVALID_ZIP'
+            hasError: 'INVALID_ZIP',
+            currentPage: 0
           })
         }
     }


### PR DESCRIPTION
Previously, if you go to page #3 of results and then search a new zip code, it would display page #3 of the new search results even if there wasn't a 3rd page. This fixes that but resetting the `currentPage` state to 0 whenever a new zip code is searched.