### PR TITLE
migration to remove foreign key constraint in UnverifiedTestCenters t…

### DIFF
--- a/src/server/db/migrations/20200612214614-unverified-no-ref-int.js
+++ b/src/server/db/migrations/20200612214614-unverified-no-ref-int.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.removeConstraint('UnverifiedTestCenters', 'UnverifiedTestCenters_staging_row_id_fkey', { transaction: t })
+      ]);
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.changeColumn('UnverifiedTestCenters', 'staging_row_id', {
+          type: Sequelize.DataTypes.INTEGER,
+          references: {
+            model: 'TestCenterStagings',
+            key: 'id',
+          },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        }, { transaction: t }),
+      ]);
+    });
+  }
+};


### PR DESCRIPTION
…able. Since diff data for the Unverified table is created using the production API, the corresponding staging table row IDs don't exist in the staging environment. In order for deploys of the diff keys to run successfully on the staging environment, there can't be a foreign key constraint on the staging_row_id column.