### PR TITLE
enabled non PID 1 processes to have access to AWS IAM credentials. Sh…

### DIFF
--- a/docker/APIDockerfile
+++ b/docker/APIDockerfile
@@ -1,6 +1,7 @@
 FROM node:12-alpine
 COPY . .
 RUN yarn install --production
+RUN echo 'export $(strings /proc/1/environ | grep AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)' >> /root/.profile
 
 EXPOSE 5000
 

--- a/src/data_pipeline/node_helpers/awsUtils.js
+++ b/src/data_pipeline/node_helpers/awsUtils.js
@@ -1,5 +1,4 @@
 const AWS = require('aws-sdk');
-const s3 = new AWS.S3();
 
 async function checkAWSAccount(callback){
     const sts = new AWS.STS();
@@ -8,6 +7,8 @@ async function checkAWSAccount(callback){
 }
 
 async function loadNewDiffFromS3(diffS3Key){
+    const s3 = new AWS.S3();
+    
     const params = {
         Bucket: 'staging-gtc-data-batches',
         Key: 'unver-staged-jobs/' + diffS3Key


### PR DESCRIPTION
…ould allow startup scripts to run diff process, which relies on downloading a remote AWS S3 file.