### PR TITLE
fixed remote docker version, in reference to a CircleCI bug.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ jobs:
         steps:
             - checkout
             - setup_remote_docker
+                version: 19.03.13
             - run: |
                   TAG=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
                   docker build -t gettestedcovid19/webserver:$TAG -f docker/Dockerfile.staging .
@@ -112,6 +113,7 @@ jobs:
         steps:
             - checkout
             - setup_remote_docker
+                version: 19.03.13
             - run: |
                   TAG=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
                   docker build -t gettestedcovid19/webserver:$TAG -f docker/Dockerfile .
@@ -125,6 +127,7 @@ jobs:
         steps:
             - checkout
             - setup_remote_docker
+                version: 19.03.13
             - run: |
                   TAG=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
                   docker build -t gettestedcovid19/api:$TAG -f docker/APIDockerfile .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
         steps:
             - checkout
             - setup_remote_docker
-                version: 19.03.13
+                  version: 19.03.13
             - run: |
                   TAG=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
                   docker build -t gettestedcovid19/webserver:$TAG -f docker/Dockerfile.staging .
@@ -113,7 +113,7 @@ jobs:
         steps:
             - checkout
             - setup_remote_docker
-                version: 19.03.13
+                  version: 19.03.13
             - run: |
                   TAG=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
                   docker build -t gettestedcovid19/webserver:$TAG -f docker/Dockerfile .
@@ -127,7 +127,7 @@ jobs:
         steps:
             - checkout
             - setup_remote_docker
-                version: 19.03.13
+                  version: 19.03.13
             - run: |
                   TAG=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
                   docker build -t gettestedcovid19/api:$TAG -f docker/APIDockerfile .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
             - image: cimg/go:1.13
         steps:
             - checkout
-            - setup_remote_docker
+            - setup_remote_docker:
                   version: 19.03.13
             - run: |
                   TAG=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
@@ -112,7 +112,7 @@ jobs:
             - image: cimg/go:1.13
         steps:
             - checkout
-            - setup_remote_docker
+            - setup_remote_docker:
                   version: 19.03.13
             - run: |
                   TAG=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
@@ -126,7 +126,7 @@ jobs:
             - image: cimg/go:1.13
         steps:
             - checkout
-            - setup_remote_docker
+            - setup_remote_docker:
                   version: 19.03.13
             - run: |
                   TAG=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:12-alpine
 COPY . .
-RUN yarn cache clean
 RUN yarn install --production
 RUN npm run build
 

--- a/docker/Dockerfile.staging
+++ b/docker/Dockerfile.staging
@@ -1,6 +1,5 @@
 FROM node:12-alpine
 COPY . .
-RUN yarn cache clean
 RUN yarn install --production
 RUN npm run build:staging
 


### PR DESCRIPTION
reference to bug: https://discuss.circleci.com/t/docker-build-fails-with-nonsensical-eperm-operation-not-permitted-copyfile/37364/27

Fixed by adding a fixed remote docker version: https://support.circleci.com/hc/en-us/articles/360050934711